### PR TITLE
全力でエラーにならないように修正

### DIFF
--- a/markdrip/main.py
+++ b/markdrip/main.py
@@ -8,10 +8,16 @@ from markdrip.mods import generator as gen
 
 @click.argument("target")
 def main(target, theme, output):
-    print(target, output, theme)
+
     mkup, filename = gen.markup(target)
     css = gen.load_css(theme)
-    gen.rendor(mkup, css, output)
+    if css != "\\[ERROR]/":
+        if output == "./":
+            output = filename + ".html"
+        print(target, output, theme)
+        gen.rendor(mkup, css, output)
+
+
 
 if __name__ == "__main__":
     main()

--- a/markdrip/mods/generator.py
+++ b/markdrip/mods/generator.py
@@ -1,12 +1,13 @@
+import os
 import pathlib
 
 import mistletoe
 from jinja2 import Template
+base = os.path.dirname(os.path.abspath(__file__))
 
-CSS_DIR = pathlib.Path("./markdrip/css/")
+CSS_DIR = os.path.normpath(os.path.join(base, '../css/'))
 CUSTOM_CSS_DIR = pathlib.Path().home() / pathlib.Path(".markdrip")
-BASE_DIR = pathlib.Path("./markdrip/templete")
-
+BASE_DIR = os.path.normpath(os.path.join(base, '../templete/'))
 
 def markup(filepath):
     filepath = pathlib.Path(filepath)
@@ -15,39 +16,48 @@ def markup(filepath):
         text = f.read()
 
     mkup = mistletoe.markdown(text)
-
-    mkup = mistletoe.markdown(text)
     return (mkup, filename)
 
 
 def load_css(css_name):
+
     load_path = CSS_DIR / pathlib.Path(css_name).with_suffix(".css")
     if load_path.exists() == True:
-        print("load_path ==> " + str(load_path))
+        print("load_path(CSS) ==> " + str(load_path))
         with open(load_path) as css_file:
             css = css_file.read()
         return css
 
     load_path = (CUSTOM_CSS_DIR / pathlib.Path(css_name).with_suffix(".css"))
-    print("load_path ==> " + str(load_path.resolve()))
-    with open(load_path) as css_file:
-        css = css_file.read()
-    return css
+    if load_path.exists() == True:
+        print("load_path ==> " + str(load_path.resolve()))
+        with open(load_path) as css_file:
+            css = css_file.read()
+        return css
+    print("EROOR")
+    print("Not Found Theme")
+    print("Theme Name ==> " + css_name + "(.css)")
+    return "\\[ERROR]/"
 
 
 
 def rendor(html, css, filename=None, basename="base.html"):
-    print(filename)
-    print("Base Template" + str(BASE_DIR / pathlib.Path(basename)))
-    with open(BASE_DIR / pathlib.Path(basename)) as tmpl:
-        templete = tmpl.read()
+    #print(filename)
+    if (BASE_DIR / pathlib.Path(basename)).exists() == True:
+        print("Base Template ==> " + str(BASE_DIR / pathlib.Path(basename)))
+        with open(BASE_DIR / pathlib.Path(basename)) as tmpl:
+            templete = tmpl.read()
 
-    templete = Template(templete)
-    data = {"content": html, "style": css, "filename": filename}
-    result = templete.render(data)
+        templete = Template(templete)
+        data = {"content": html, "style": css, "filename": filename}
+        result = templete.render(data)
 
-    path = pathlib.Path(filename).resolve()
+        path = pathlib.Path(filename).resolve()
 
-    with open(path, "w") as f:
-        print("write ==> " + str(path))
-        f.write(result)
+        with open(path, "w") as f:
+            print("write ==> " + str(path))
+            f.write(result)
+    else:
+        print("EROOR")
+        print("Not Found Templete")
+        print("Theme Templete ==> " + basename + "(.html)")


### PR DESCRIPTION
とにかくエラーが出にくいようにしておきました
* templeteとthemeをまずmarkdrip\cssとmarkdrip\templeteを参照するように修正
* 存在しないtemplete・themeを参照しようとしたときにエラーを吐くように
* rendorの中にある#print(filename)をコメントアウトしておきました。
  不都合があれば戻しておいてください

あと、Linux、Macの環境は試せてません。
スミマセン